### PR TITLE
feat: Add ability to add Version manually

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -23,6 +23,7 @@ module.exports = {
                 pbxprojPath: config.project.ios.pbxprojPath,
                 buildGradlePath: appGradlePath,
                 type: args.type,
+                version: args.version,
                 skipCodeFor: args.skipCodeFor
                     ? args.skipCodeFor.split(' ')
                     : [],
@@ -35,6 +36,10 @@ module.exports = {
             {
                 name: '--type [major|minor|patch]',
                 description: 'SemVer release type, optional if --skip-semver-for all is passed'
+            },
+            {
+                name: '--version [String]',
+                description: 'Pass release version if known. Overwrites calculated SemVer. Optional.'
             },
             {
                 name: '--skip-semver-for [android|ios|all]',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type Platforms = 'android' | 'ios' | 'all'
 
 type Configs = {
     type?: SemVer
+    version: string
     skipSemVerFor: Platforms[]
     skipCodeFor: Platforms[]
     root: string
@@ -30,8 +31,12 @@ const matchFirst = curry((reg: RegExp, value: string) => {
     return first
 })
 
-const incrementSemVer = (version: string, type: SemVer | undefined) => {
-    const [major, minor, patch] = parseSemVer(version)
+const incrementSemVer = (current: string, version: string | null, type: SemVer | undefined) => {
+    const [major, minor, patch] = parseSemVer(current)
+    
+    if(version) {
+        return version
+    }    
 
     if (type === 'major') {
         return [major + 1, 0, 0].join('.')
@@ -272,9 +277,9 @@ export class ProjectFilesManager {
      * This executes changes but don't actually write anything to fs
      */
     dryRun() {
-        const { type, skipSemVerFor, skipCodeFor } = this.configs
+        const { type, version, skipSemVerFor, skipCodeFor } = this.configs
         const current = this.packageJSON.getVersion()
-        const next = incrementSemVer(current, type ?? 'minor')
+        const next = incrementSemVer(current, version, type ?? 'minor')
 
         if (!skipCodeFor.includes('all')) {
             this.bumpCodes()

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export type Platforms = 'android' | 'ios' | 'all'
 
 type Configs = {
     type?: SemVer
-    version: string
+    version?: string
     skipSemVerFor: Platforms[]
     skipCodeFor: Platforms[]
     root: string
@@ -31,12 +31,8 @@ const matchFirst = curry((reg: RegExp, value: string) => {
     return first
 })
 
-const incrementSemVer = (current: string, version: string | null, type: SemVer | undefined) => {
+const incrementSemVer = (current: string, type: SemVer | undefined) => {
     const [major, minor, patch] = parseSemVer(current)
-    
-    if(version) {
-        return version
-    }    
 
     if (type === 'major') {
         return [major + 1, 0, 0].join('.')
@@ -279,7 +275,7 @@ export class ProjectFilesManager {
     dryRun() {
         const { type, version, skipSemVerFor, skipCodeFor } = this.configs
         const current = this.packageJSON.getVersion()
-        const next = incrementSemVer(current, version, type ?? 'minor')
+        const next = version ?? incrementSemVer(current, type ?? 'minor')
 
         if (!skipCodeFor.includes('all')) {
             this.bumpCodes()


### PR DESCRIPTION
**User Story**
As a developer I want to be able to define the Version manually.

**Background**
If for example you use CLI on CI level, you probably use Semantic Release (https://www.npmjs.com/package/semantic-release) to define the Versions of the Application. In this case, the versions created by react-native-cli-bump-version and Semantic Release will be different. To be able to use it with SR it will be good to add additional parameter to this CLI.

P.S. The changes were not tested tbh...sorry for that! 
P.S.S. Thank you for your work!