### PR TITLE
fix: prefer buildGradlePath from cli instead of path.join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0
+
+Made the cli prefer using the `buildGradlePath` from RN cli, this probably doesn't 
+break any existing project, but for safety I'm doing a minor here.
+
 # 1.1.0
 
 Changed `--version` flag to `--semver` due to issues with react-native

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cli-bump-version",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -11,7 +11,7 @@ module.exports = {
                 return
             }
 
-            const appGradlePath = path.join(
+            const appGradlePath = config.project.android.buildGradlePath || path.join(
                 config.project.android.sourceDir,
                 config.project.android.appName,
                 'build.gradle'


### PR DESCRIPTION
Somehow RN cli app name may be `undefined`, causing exceptions on the path join call, to mitigate this, I've added a preference to use the cli's `buildGradlePath`